### PR TITLE
Add IntersectionObserver scroll animation

### DIFF
--- a/src/app/pages/growth/growth.component.html
+++ b/src/app/pages/growth/growth.component.html
@@ -25,7 +25,7 @@
   </div>
   <div class="growths">
     <!-- <router-outlet></router-outlet> -->
-    <div *ngFor="let month of months" class="photo-growth">
+    <div *ngFor="let month of months" class="photo-growth" #photoSection>
       <img [src]="month.src" [alt]="month.alt" class="photo-item">
     </div>
     <!-- <div class="photo-growth">

--- a/src/app/pages/growth/growth.component.scss
+++ b/src/app/pages/growth/growth.component.scss
@@ -79,66 +79,28 @@
 
 .growths {
   width: 100%;
-  max-width: 800px;  /* 최대 너비 지정 */
-  max-height: 100%;
-  padding: 0.1rem;
-  background-color: white;
-  border-radius: 8px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-  overflow: hidden;
+  position: relative;
 
   .photo-growth {
+    position: relative;
+    height: 100vh;
+    overflow: hidden;
     display: flex;
-    flex-wrap: wrap;
+    align-items: center;
     justify-content: center;
-    // aspect-ratio: 3 / 2; /* 가로 세로 비율 */
-    // width: 200px;
-    padding: 1rem;
-    background-color: #f9f9f9;
-    border-radius: 8px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-    max-width: 600px;
-    margin: 10px;
-  }
-  
-  .photo-item {
-    // width: 150px;
-    height: auto;
-    margin: 10px;
-  }
-  
-  img {
-    /* 컨테이너 크기에 맞게 이미지 조정 */
-    width: 100%;       /* 컨테이너 너비에 맞춤 */
-    height: auto;      /* 비율 유지 */
-    max-width: 100%;   /* 컨테이너를 넘어가지 않도록 제한 */
-    max-height: 100%;  /* 컨테이너 높이를 넘어가지 않도록 제한 */
-    object-fit: cover; /* 이미지가 잘리지 않고 고르게 채워지도록 설정 */
-    display: block;    /* 여백 제거 */
-    margin: 0 auto;    /* 중앙 정렬 (선택 사항) */
-    // transition: transform 0.3s ease, opacity 0.3s ease;
-    transition: transform 0.5s ease, opacity 0.5s ease;
-    opacity: 0.7;
   }
 
-  img.in-view {
+  .photo-item {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transform: scale(1.05);
+    opacity: 0;
+    transition: transform 1s ease, opacity 1s ease;
+  }
+
+  .photo-growth.visible .photo-item {
     transform: scale(1);
     opacity: 1;
   }
-  
-  img:not(.in-view) {
-    transform: scale(0.9);
-    opacity: 0.7;
-  }
-  
-  @keyframes imageGrow {
-    from {
-      transform: scale(0.9);
-      opacity: 0.7;
-    }
-    to {
-      transform: scale(1);
-      opacity: 1;
-    }
-  }  
 }

--- a/src/app/pages/growth/growth.component.ts
+++ b/src/app/pages/growth/growth.component.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, ElementRef, HostListener, Renderer2 } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { AfterViewInit, Component, ElementRef, QueryList, Renderer2, ViewChildren } from '@angular/core';
 
 @Component({
   selector: 'app-growth',
@@ -9,13 +8,15 @@ import { ActivatedRoute, Router } from '@angular/router';
   templateUrl: './growth.component.html',
   styleUrl: './growth.component.scss'
 })
-export class AboutComponent {
+export class AboutComponent implements AfterViewInit {
 
   months: { src: string, alt: string }[] = [];
 
   birthDate: Date = new Date('2024-08-01'); // 예시 출생일
   monthsSinceBirth: number = Math.floor((new Date().getTime() - this.birthDate.getTime()) / (1000 * 60 * 60 * 24 * 30));
   
+  @ViewChildren('photoSection', { read: ElementRef }) photoSections!: QueryList<ElementRef>;
+
   constructor(private el: ElementRef, private renderer: Renderer2) {
     for (let month = this.monthsSinceBirth - 1; month >= 0; month--) {
       this.months.push({
@@ -26,19 +27,23 @@ export class AboutComponent {
     this.months.push({ src: 'birth.jpg', alt: '출생 기록' });
   }  
 
-  @HostListener('window:scroll', [])
-  onScroll(): void {
-    const images = this.el.nativeElement.querySelectorAll('img');
+  ngAfterViewInit(): void {
+    if ('IntersectionObserver' in window) {
+      const observer = new IntersectionObserver(entries => {
+        entries.forEach(entry => {
+          const target = entry.target as HTMLElement;
+          if (entry.isIntersecting) {
+            this.renderer.addClass(target, 'visible');
+          } else {
+            this.renderer.removeClass(target, 'visible');
+          }
+        });
+      }, { threshold: 0.5 });
 
-    images.forEach((img: HTMLElement) => {
-      const rect = img.getBoundingClientRect();
-      const inView = rect.top >= 0 && rect.bottom <= window.innerHeight;
-
-      if (inView) {
-        this.renderer.addClass(img, 'in-view');
-      } else {
-        this.renderer.removeClass(img, 'in-view');
-      }
-    });
+      this.photoSections.forEach(section => observer.observe(section.nativeElement));
+    } else {
+      // Fallback for older browsers
+      this.photoSections.forEach(section => this.renderer.addClass(section.nativeElement, 'visible'));
+    }
   }
 }


### PR DESCRIPTION
## Summary
- animate growth page photos with a new IntersectionObserver
- modernize the growth page CSS so each image fills the screen and fades in when visible

## Testing
- `npm test` *(fails: `ng: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68465efdb068832e9ad72a9f3ed8261b