### PR TITLE
Add design placeholders to home and about pages

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,8 +1,19 @@
 <div class="home">
-  <p class="text">은수야 태어나줘서 고마워</p>
-</div>
-<div class="heart">
-  <div class="sparkle"></div>
-  <div class="sparkle"></div>
-  <div class="sparkle"></div>
+  <section class="hero">
+    <h2 class="hero-title">Welcome to Eunttu's Memory</h2>
+    <p class="hero-sub">A place to keep lovely moments.</p>
+  </section>
+
+  <section class="features">
+    <div class="feature" *ngFor="let item of features">
+      <h3>{{ item.title }}</h3>
+      <p>{{ item.desc }}</p>
+    </div>
+  </section>
+
+  <div class="heart">
+    <div class="sparkle"></div>
+    <div class="sparkle"></div>
+    <div class="sparkle"></div>
+  </div>
 </div>

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -1,11 +1,43 @@
-.home {
-    .text {
-        text-align: center;
-    }
-}
 $heart-size: 100px;
 $heart-color: pink;
-.heart {
+
+.home {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  .hero {
+    text-align: center;
+    padding: 2rem 1rem;
+    background-color: #f6f8fa;
+    border-radius: 8px;
+    margin-top: 60px;
+    width: 90%;
+    max-width: 800px;
+
+    .hero-title {
+      margin: 0 0 0.5rem;
+    }
+  }
+
+  .features {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+    margin: 2rem 0;
+    width: 90%;
+    max-width: 800px;
+
+    .feature {
+      background-color: white;
+      border-radius: 8px;
+      padding: 1rem;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+      text-align: center;
+    }
+  }
+
+  .heart {
     margin: 100px;
     position: relative;
     width: $heart-size;
@@ -16,26 +48,26 @@ $heart-color: pink;
 
     &:before,
     &:after {
-        content: '';
-        position: absolute;
-        width: $heart-size;
-        height: $heart-size;
-        background-color: $heart-color;
-        border-radius: 50%;
+      content: '';
+      position: absolute;
+      width: $heart-size;
+      height: $heart-size;
+      background-color: $heart-color;
+      border-radius: 50%;
     }
 
     &:before {
-        top: -50%;
-        left: 0;
+      top: -50%;
+      left: 0;
     }
 
     &:after {
-        left: 50%;
-        top: 0;
+      left: 50%;
+      top: 0;
     }
-}
+  }
 
-.sparkle {
+  .sparkle {
     position: absolute;
     width: 5px;
     height: 5px;
@@ -46,33 +78,32 @@ $heart-color: pink;
     z-index: 100;
 
     &:nth-child(1) {
-        top: 10%;
-        left: 20%;
+      top: 10%;
+      left: 20%;
     }
 
     &:nth-child(2) {
-        top: 40%;
-        left: 120%;
-        animation-delay: 0.5s;
+      top: 40%;
+      left: 120%;
+      animation-delay: 0.5s;
     }
 
     &:nth-child(3) {
-        top: 80%;
-        left: 30%;
-        animation-delay: 1s;
+      top: 80%;
+      left: 30%;
+      animation-delay: 1s;
     }
+  }
 }
 
 @keyframes sparkle {
-
-    0%,
-    100% {
-        transform: scale(0.5);
-        opacity: 0.5;
-    }
-
-    50% {
-        transform: scale(1.2);
-        opacity: 1;
-    }
+  0%,
+  100% {
+    transform: scale(0.5);
+    opacity: 0.5;
+  }
+  50% {
+    transform: scale(1.2);
+    opacity: 1;
+  }
 }

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -8,4 +8,9 @@ import { Component } from '@angular/core';
 })
 export class HomeComponent {
 
+  features = [
+    { title: 'First Steps', desc: 'Sample description about first steps.' },
+    { title: 'First Word', desc: 'Sample description about first words.' },
+    { title: 'First Birthday', desc: 'Sample description about first birthday.' },
+  ];
 }

--- a/src/app/pages/about/about.component.html
+++ b/src/app/pages/about/about.component.html
@@ -1,4 +1,9 @@
 <div class="about">
+  <section class="intro">
+    <h2>About Eunttu</h2>
+    <p class="intro-text">Sample introduction text goes here.</p>
+  </section>
+
   <div class="buttonArea">
     <p>about Eunttu!</p>
     <button class="button" (click)="navigateTo('')">❤</button>

--- a/src/app/pages/about/about.component.scss
+++ b/src/app/pages/about/about.component.scss
@@ -14,6 +14,11 @@
   // width: 100%; // 컨테이너의 너비에 맞춤
 }
 
+.intro {
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+
 /* .buttonArea 스타일 */
 .buttonArea {
   display: flex;

--- a/src/app/pages/about/data/data.component.html
+++ b/src/app/pages/about/data/data.component.html
@@ -1,15 +1,6 @@
 <div class="info">
-  <div class="info-item">
-    <span class="key">age:</span>
-    <span class="value">0 years old
-    </span>
-  </div>
-  <div class="info-item">
-    <span class="key">height:</span>
-    <span class="value">74cm</span>
-  </div>
-  <div class="info-item">
-    <span class="key">weight:</span>
-    <span class="value">9.6kg</span>
+  <div class="info-item" *ngFor="let item of infoItems">
+    <span class="key">{{ item.key }}:</span>
+    <span class="value">{{ item.value }}</span>
   </div>
 </div>

--- a/src/app/pages/about/data/data.component.ts
+++ b/src/app/pages/about/data/data.component.ts
@@ -7,5 +7,11 @@ import { Component } from '@angular/core';
   styleUrl: './data.component.scss'
 })
 export class DataComponent {
-
+  infoItems = [
+    { key: 'Age', value: '0 years old' },
+    { key: 'Height', value: '74cm' },
+    { key: 'Weight', value: '9.6kg' },
+    { key: 'Blood Type', value: 'A' },
+    { key: 'Favorite Toy', value: 'Sample toy' },
+  ];
 }

--- a/src/app/pages/about/photos/photos.component.html
+++ b/src/app/pages/about/photos/photos.component.html
@@ -1,3 +1,5 @@
 <div class="photo-gallery">
-  <img src="recent.jpg" alt="최신 은수" class="photo-item" width="150px">
+  <div class="photo-item" *ngFor="let photo of photos">
+    <img [src]="photo.src" [alt]="photo.alt" />
+  </div>
 </div>

--- a/src/app/pages/about/photos/photos.component.scss
+++ b/src/app/pages/about/photos/photos.component.scss
@@ -1,9 +1,7 @@
 .photo-gallery {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  // aspect-ratio: 3 / 2; /* 가로 세로 비율 */
-  width: 200px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 1rem;
   padding: 1rem;
   background-color: #f9f9f9;
   border-radius: 8px;
@@ -13,9 +11,8 @@
 }
 
 .photo-item {
-  width: 150px;
+  width: 100%;
   height: auto;
-  margin: 10px;
 }
 
 img {

--- a/src/app/pages/about/photos/photos.component.ts
+++ b/src/app/pages/about/photos/photos.component.ts
@@ -7,5 +7,8 @@ import { Component } from '@angular/core';
   styleUrl: './photos.component.scss'
 })
 export class PhotosComponent {
-
+  photos = [
+    { src: 'recent.jpg', alt: 'Recent Eunttu' },
+    { src: 'eunttu.jpg', alt: 'Sample image' }
+  ];
 }


### PR DESCRIPTION
## Summary
- add hero and feature sections on the home page
- populate about pages with sample data and photo lists
- introduce intro section on the about page
- tweak styles for new layout

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684664631c5c832e8911c8c2604e7f09